### PR TITLE
fix `/lib` directory, to be compliant with `filesystem` package update

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,16 @@ and replace with:
 
 Save and exit the editor.
 
+### 2.10 Update `/lib` structure
+In Archlinux, `/lib` is just a symbolic link to `/usr/lib`.
+```bash
+cd Linux_for_Tegra
+
+sudo rsync -avxHAX lib/ usr/lib/
+sudo rm -rf lib
+sudo ln -s usr/lib lib
+```
+
 ## 3. Flashing the Jetson Nano
 Make sure your Jetson Nano is in recovery mode using a Jumper.
 Depending on which Jetson Nano Board you have, this pin will be in different locations, refer to the Image below:

--- a/arch-nano.fish
+++ b/arch-nano.fish
@@ -203,7 +203,12 @@ echo -e "$RED Done, $WHITE creating symlinks"
 
 sudo cp rootfs/usr/lib/ld-linux-aarch64.so.1 rootfs/lib/ld-linux-aarch64.so.1
 
-cd rootfs/etc/systemd/system/sysinit.target.wants/
-sudo ln -s ../../../../usr/lib/systemd/system/nvidia-tegra.service nvidia-tegra.service
+sudo ln -sr rootfs/usr/lib/systemd/system/nvidia-tegra.service rootfs/etc/systemd/system/sysinit.target.wants/nvidia-tegra.service
+
+echo -e "$RED Done, $WHITE updating /lib structure..."
+
+sudo rsync -avxHAX lib/ usr/lib/
+sudo rm -rf lib
+sudo ln -s usr/lib lib
 
 echo -e "$RED Done, $WHITE Script has Finished!$RESET"

--- a/arch-nano.sh
+++ b/arch-nano.sh
@@ -203,7 +203,12 @@ echo -e "${RED}Done, ${WHITE}creating symlinks"
 
 sudo cp rootfs/usr/lib/ld-linux-aarch64.so.1 rootfs/lib/ld-linux-aarch64.so.1
 
-cd rootfs/etc/systemd/system/sysinit.target.wants/
-sudo ln -s ../../../../usr/lib/systemd/system/nvidia-tegra.service nvidia-tegra.service
+sudo ln -sr rootfs/usr/lib/systemd/system/nvidia-tegra.service rootfs/etc/systemd/system/sysinit.target.wants/nvidia-tegra.service
+
+echo -e "${RED}Done, ${WHITE}updating /lib structure..."
+
+sudo rsync -avxHAX lib/ usr/lib/
+sudo rm -rf lib
+sudo ln -s usr/lib lib
 
 echo -e "${RED}Done, ${WHITE}Script has Finished!${RESET}"


### PR DESCRIPTION
In Archlinux, `/lib` is just a symbolic link to `/usr/lib`.